### PR TITLE
Corrected DM typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Emily will respond to all messages in a channel once she is greeted. It is not r
 - Say goodbye with 'Bye Emily' to disengage and delete the chat history for the current channel
 
 ### DMs
-Emily is always on in DMs and will respond to any chat, but it is best tp continue using Hey Emily and Bye Emily until improvements can be made to her listening logic. Outside of that, simply open a DM with her and speak with her as you would anyone else. 
+Emily is always on in DMs and will respond to any chat, but it is best to continue using Hey Emily and Bye Emily until improvements can be made to her listening logic. Outside of that, simply open a DM with her and speak with her as you would anyone else. 
 - You can delete your chat history from Emily's database by saying `Bye Emily` when she is listening after saying Hey Emily.
 - If Emily doesn't respond to Bye Emily greet her with Hey Emily and then try again. This will trigger her to listen for the command, this will be improved in the future.
 


### PR DESCRIPTION
Closes #31 

This pull request includes a minor correction to the `README.md` file. A typographical error in the documentation was fixed to improve clarity.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15): Corrected a typo by changing "tp" to "to" in the description of how Emily responds in DMs.